### PR TITLE
Llamasoft Map Exercise - Mark Evans

### DIFF
--- a/Map.css
+++ b/Map.css
@@ -1,3 +1,7 @@
+body {
+    font-family: 'Source Sans Pro', sans-serif;
+}
+
 #airport-settings {
     width: calc(100% - 8px);
     border: 2px solid black;
@@ -24,12 +28,35 @@
 }
 
 #airport-map{
-    width: 800px;
+    width: 70%;
     height: 600px;
+}
+
+#airport-controls {
+    position: absolute;
+    top: -1.75em;
+    right: 4em;
+}
+
+#exercise.show_list div#airport-map {
+    width: 100%;
+}
+
+#airport-wrapper {
+    width: 25%;
+    float: right;
+    margin-left: 1em;
+    border: 1px solid lightgray;
+    border-radius: 5px;
+}
+
+#exercise.show_list div#airport-wrapper {
+    display: none;
 }
 
 #airport-data {
     margin: 12px;
+    display: none;
 }
 
 #exercise-toggle {
@@ -42,3 +69,91 @@
     font-size: 32px;
     font-weight: bold;
 }
+
+#exercise {
+    display: flex;
+    position: relative;
+    margin-top: 3em;
+}
+
+div.airport {
+    border: 1px solid lightgray;
+    border-radius: 3px;
+    margin: 0.5em;
+    padding: 0.5em;
+    background-color: #f8fcff;
+    font-size: smaller;
+    position: relative;
+}
+
+    div.airport div.remove_airport {
+        position: absolute;
+        font-weight: bold;
+        top: 0.35em;
+        right: 0.35em;
+        cursor: pointer;
+    }
+
+    div.airport div.city {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-bottom: 0.5em;
+    }
+
+    div.airport div.name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-weight: bold;
+        margin-right: 0.5em;
+        margin-bottom: 0.25em;
+    }
+
+    div.airport div.controls {
+        height: 1em;
+        width: 100%;
+    }
+
+    div.airport div.controls div {
+        float: right;
+        margin-left: 0.5em;
+        margin-right: 0.5em;
+        font-size: small;
+        cursor: pointer;
+    }
+
+div.show.include {
+    color: #3137FD;
+}
+
+    div.airport div.coords {
+        margin-left: 2em;
+        height: 1.5em;
+        font-style: italic;
+        font-size: x-small;
+    }
+
+        div.airport div.coords div {
+            float: left;
+            margin-right: 1em;
+        }
+
+div.counter {
+    font-size: x-small;
+    font-style:italic;
+    float: right;
+    margin-top: 0.25em;
+    margin-left: 0.5em;
+}
+
+div.list_toggle {
+    float: right;
+    margin-left: 1em;
+    cursor: pointer;
+    color: black;
+}
+
+    div.list_toggle.show_list {
+        color: #3137FD;
+    }

--- a/Map.html
+++ b/Map.html
@@ -4,9 +4,10 @@
         <title>Map Sample</title>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE&callback=initMap"></script>
+        <script src="https://use.fontawesome.com/854c8aa5dd.js"></script>
         <script src="siteData.js"></script>
         <script src="Map.js"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBpKE_r7YdE6cfRkQNy7QHZIzGQw2zpLSY&callback=initMap" async defer></script>
         <link href="Map.css" rel="stylesheet">
     </head>
     <body>
@@ -29,7 +30,7 @@
             
             <p>
             Currently this page loads a list of airports into a drop down. You can select an airport
-            and it&quot;s code and city will display in the data table. A marker will be placed on the
+            and its code and city will display in the data table. A marker will be placed on the
             map displaying the airport. If you roll your mouse over the marker the airport&quot;s code
             will be displayed.
             </p>
@@ -58,32 +59,33 @@
             </p>
             </div>
         </div>
-        
-        <div id="airport-map">
-        </div>
-        
-        <div id="airport-data">
-            <div id="airport-controls">        
-                Airports: <select id="airport-list">
-                </select>
+        <div id="exercise">
+            <div id="airport-controls">
+                <select id="airport-list"></select>
             </div>
-            
-            <div id="airport-settings">
-                <div id="setting-name">
-                    <div>Code</div>
-                    <div>City</div>
-                    <div>State</div>
-                    <div>Full Name</div>
-                    <div>Latitude</div>
-                    <div>Longitude</div>
-                </div>
-                <div id="setting-value">
-                    <div id="setting-code"></div>
-                    <div id="setting-city"></div>
-                    <div id="setting-state"></div>
-                    <div id="setting-name"></div>
-                    <div id="setting-lat"></div>
-                    <div id="setting-long"></div>
+            <div id="airport-map">
+            </div>
+            <div id="airport-wrapper">
+                <div id="sel-airport-container"></div>
+            </div>
+            <div id="airport-data">
+                <div id="airport-settings">
+                    <div id="setting-name">
+                        <div>Code</div>
+                        <div>City</div>
+                        <div>State</div>
+                        <div>Full Name</div>
+                        <div>Latitude</div>
+                        <div>Longitude</div>
+                    </div>
+                    <div id="setting-value">
+                        <div id="setting-code"></div>
+                        <div id="setting-city"></div>
+                        <div id="setting-state"></div>
+                        <div id="setting-fullname"></div>
+                        <div id="setting-lat"></div>
+                        <div id="setting-long"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/Map.js
+++ b/Map.js
@@ -1,65 +1,214 @@
+/// <reference path="Map.html" />
 var globalMap;
+var markers = {};
 
 $(function() {
 
 var MapFcns = {
     loadSiteList: function () {
         var airportList = $('#airport-list');
-            airportList.html('');
-            airportList.append('<option value=""></option>');
+        //airportList.html('');
+        
         for (var i in sites) {
-            var newOption = $('<option value="' + sites[i].Code + '">' + sites[i].Code + '</option>');
+            // if 'FullSiteName' has that funky prefix, remove it and store it in 'AirportName'
+            if (sites[i].FullSiteName.indexOf("_" + sites[i].Code + "_") >= 0) {    
+                sites[i]["AirportName"] = sites[i].FullSiteName.substr(sites[i].FullSiteName.indexOf("_" + sites[i].Code + "_") + 5);
+            }
+            else {
+                sites[i]["AirportName"] = sites[i].FullSiteName;
+            }
+            sites[i]["CityStateLabel"] = sites[i].City + (sites[i].City.indexOf(',') < 0 ? ", " + sites[i].State : "");
+            var newOption = $('<option value="' + sites[i].Code + '">' + sites[i].CityStateLabel
+                + " (" + sites[i].Code + ")" + '</option>');
+            newOption.data("airport_data", sites[i]);
             airportList.append(newOption);
         }
+        var option_list = $(airportList).children();
+        option_list.detach();
+        option_list.sort(function (a, b) {  //sort list by City
+            return ($(b).text() < $(a).text()) ? 1 : -1;
+        });
+        airportList.prepend("<option value='' disabled='disabled'>Select an Airport</option>");
+        airportList.append(option_list);
+        airportList.val(null);
     },
-    
+
+    updateCount: function () {
+        $("div.counter").text($("div.airport").length);
+    },
+
     siteListChange: function() {
-        var ctl = $(this),
-            airportCode = ctl.val();
-            if(airportCode) {
-                var currAirport = _.findWhere(sites, {Code: airportCode});
-                $('#setting-code').text(currAirport.Code);
-                $('#setting-city').text(currAirport.City);
-                
-                var marker = new google.maps.Marker({
-                    position: {lat: currAirport.Latitude, lng: currAirport.Longitude},
-                    map: globalMap,
-                    title: currAirport.Code
+        var ctl = $(this);
+        google.maps.event.clearListeners(globalMap, 'bounds_changed');
+        globalMap.addListener('bounds_changed', function () {
+            MapFcns.configureAirports();
+        });
+        var airport_data = ctl.children("option[value='" + ctl.val() + "']").data("airport_data");
+        if (airport_data) {
+                //var currAirport = _.findWhere(sites, {Code: airportCode});
+            //$('#setting-code').text(airport_data.Code);
+            //$('#setting-city').text(airport_data.City);
+            //$('#setting-state').text(airport_data.State);
+            //$('#setting-fullname').text(airport_data.AirportName);
+            //$('#setting-lat').text(airport_data.Latitude);
+            //$('#setting-long').text(airport_data.Longitude);
+
+            var contentString = "<div class='name' title='" + airport_data.AirportName + "' style='font-weight:bold;'>" // content of marker infowindow
+                + airport_data.AirportName.replace("International", "Intl") + "</div>"
+                +"<div class='city'>" + airport_data.CityStateLabel + " (" + airport_data.Code + ")</div>"
+                + "<div class='coords'><div class='lat' style='float:left'>" + airport_data.Latitude
+                + " lat</div><div class='lon' style='float:left; margin-left:1em;'>" + airport_data.Longitude + " lon</div></div>"
+            var infowindow = new google.maps.InfoWindow({
+                content: contentString
+            });
+            var marker = new google.maps.Marker({
+                position: { lat: airport_data.Latitude, lng: airport_data.Longitude },
+                map: globalMap,
+                title: airport_data.Code,
+                icon: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png"
+            });
+            marker.id = airport_data.Code;
+            //marker.addListener('click', function () {
+            //    infowindow.open(globalMap, marker);
+            //});
+
+            google.maps.event.addListener(marker, 'click', function () {
+                if (!marker.open) {
+                    infowindow.open(globalMap, marker);
+                    marker.open = true;
+                }
+                else {
+                    infowindow.close();
+                    marker.open = false;
+                }
+                google.maps.event.addListener(globalMap, 'click', function () {
+                    infowindow.close();
+                    marker.open = false;
                 });
+            });
+            markers["airport_" + airport_data.Code] = marker;
+            MapFcns.addSelectedAirport(airport_data);
+        }
+    },
+
+    addSelectedAirport: function (airport_data) {       // add airport to list of selected airports
+        var airport = document.createElement("div");
+        $(airport).attr("id", "airport_" + airport_data.Code);
+        $(airport).addClass("airport");
+        $(airport).data(airport_data);
+        $(airport).append("<div class='name' title='" + airport_data.AirportName + "'>" + airport_data.AirportName + "</div><div class='remove_airport'>x</div>"
+            + "<div class='city'>" + airport_data.CityStateLabel + " (" + airport_data.Code + ")</div>"
+            + "<div class='coords'><div class='lat'>" + airport_data.Latitude + " lat</div><div class='lon'>" + airport_data.Longitude + " lon</div></div>"
+            + "<div class=controls><div class='center' title='center map on airport'><i class='fa fa-bullseye'></i></div><div class='show include' title='add to view'><i class='fa fa-map-marker'></i></div></div>");
+
+        // set click events for three controls in 'airport' div
+        $(airport).find("div.remove_airport").click(function () {
+            MapFcns.removeAirport($(this).closest("div.airport"));
+        });
+        $(airport).find("div.center").click(function () {   // set click event for 'center' button
+            MapFcns.centerOnAirport($(this).closest("div.airport"));
+        });
+        $(airport).find("div.show").click(function () {     // set click event for 'show' button (includes marker in map view)
+            $(this).toggleClass("include");
+            MapFcns.lassoAirports();
+        });
+        $("#sel-airport-container").append(airport);
+
+        // disable option in select for this airport so it cannot be added twice
+        $("#airport-list").children("option[value='" + airport_data.Code + "']").attr("disabled", "disabled");
+        MapFcns.updateCount();
+        MapFcns.lassoAirports();
+    },
+
+    centerOnAirport: function (airport) {   // center map on selected airport
+        airport_code = airport.data("Code");
+        marker = markers[airport.attr("id")];
+        globalMap.setCenter(marker.position);
+    },
+
+    lassoAirports: function () {        //fits all airports flagged to "show" into map view
+        var minlat = 0, maxlat = 0, minlon = 0, maxlon = 0;
+        var updateBounds = ($("div.show.include").length > 0);
+        $("div.show.include").each(function (index, show) {
+            airport_data = $(show).closest("div.airport").data();
+            if (index === 0) {
+                minlat = airport_data.Latitude;
+                maxlat = airport_data.Latitude;
+                minlon = airport_data.Longitude;
+                maxlon = airport_data.Longitude;
             }
+            minlat = minlat < airport_data.Latitude ? minlat : airport_data.Latitude;
+            maxlat = maxlat > airport_data.Latitude ? maxlat : airport_data.Latitude;
+            minlon = minlon < airport_data.Longitude ? minlon : airport_data.Longitude;
+            maxlon = maxlon > airport_data.Longitude ? maxlon : airport_data.Longitude;
+        });
+        if (updateBounds) {
+            globalMap.fitBounds({ east: maxlon, south: minlat, west: minlon, north: maxlat });
+            var current_zoom = globalMap.getZoom();
+            if (current_zoom > 11) {
+                globalMap.setZoom(11);
+            }
+        }
+    },
+
+    configureAirports: function () {
+        $("div.show.include").each(function (index, show) {     //if airport falls out of view due to user, un "show" the aiport.
+            airport_data = $(show).closest("div.airport").data();
+            var marker = markers["airport_" + airport_data.Code];
+            if (!marker || !globalMap.getBounds().contains(marker.getPosition())) {
+                $(show).removeClass("include");
+            }
+        });
+    },
+
+    removeAirport: function (airport) {
+        airport_code = airport.data("Code");
+        marker = markers[airport.attr("id")];
+        marker.setMap(null);
+        airport.fadeOut("fast",
+            function () {
+                airport.remove();
+                MapFcns.updateCount();
+                // enable airport in select list so user can add again if needed
+                $("#airport-list").children("option[value='" + airport_code + "']").removeAttr("disabled");
+                if ($("#airport-list").val() === airport_code) {
+                    $("#airport-list").val("");
+                }
+            });
     }
 }
 
 
 MapFcns.loadSiteList();
-$('#airport-list').change(MapFcns.siteListChange);
-$('#exercise-toggle').click(function() {
-    var  toggleCtl = $(this),
-         toggleVal = toggleCtl.text();
-    if (toggleVal == '-') {
-        toggleCtl.text('+');
-        $('#exercise-instructions').hide();
-    } else {
-        toggleCtl.text('-');
-        $('#exercise-instructions').show();
-    }
+    $('#airport-list').change(MapFcns.siteListChange);
+    $('#exercise-toggle').click(function() {
+        var  toggleCtl = $(this),
+             toggleVal = toggleCtl.text();
+        if (toggleVal == '-') {
+            toggleCtl.text('+');
+            $('#exercise-instructions').hide();
+        } else {
+            toggleCtl.text('-');
+            $('#exercise-instructions').show();
+        }
+    });
+    $("#airport-controls").append("<div class='list_toggle show_list' title='show/hide list'>"  //add button to show/hide airport list
+        + "<i class='fa fa-plane'></i><div class='counter'>0</div></div>");
+    $("div.list_toggle").click(function () {
+        $(this).toggleClass("show_list");
+        $("#exercise").toggleClass("show_list");
+        google.maps.event.trigger(globalMap, 'resize');     // repaint map with new div size
+        MapFcns.lassoAirports();                            //fit bounds to airports
+    });
 });
-
-});
-
-
-
-
-
-
-
     
 function  initMap() {
-  // Callback function to create a map object and specify the DOM element for display.
-  globalMap = new google.maps.Map(document.getElementById('airport-map'), {
+    // Callback function to create a map object and specify the DOM element for display.
+    var myStyle = [{ "featureType": "administrative", "elementType": "labels.text.fill", "stylers": [{ "color": "#444444" }] }, { "featureType": "landscape", "elementType": "all", "stylers": [{ "color": "#f2f2f2" }] }, { "featureType": "poi", "elementType": "all", "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "elementType": "all", "stylers": [{ "saturation": -100 }, { "lightness": 45 }] }, { "featureType": "road.highway", "elementType": "all", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "road.arterial", "elementType": "labels.icon", "stylers": [{ "visibility": "off" }] }, { "featureType": "transit", "elementType": "all", "stylers": [{ "visibility": "off" }] }, { "featureType": "water", "elementType": "all", "stylers": [{ "color": "#46bcec" }, { "visibility": "on" }, { "saturation": -75 }] }];
+    globalMap = new google.maps.Map(document.getElementById('airport-map'), {
     center: {lat: 42.2814, lng: -83.7483},
     scrollwheel: true,
-    zoom: 6
-  });
-  
-    }
+    zoom: 6,
+    styles: myStyle
+    });
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# map-demo - committed version from Mark Evans
+
+Changes:
+
+* Updated selected to contain City/State and sort by City. Also, airports added are disabled/enabled in select list
+to prevent double-adding.
+* Added list of airports on right side of browser with toggle show/hide.
+  - airport div has info and controls to remove airport, center map on airport, and include in map view.
+* Added infowindow (callout) to google map marker that opens when marker is clicked and closes if clicked again.


### PR DESCRIPTION
- Updated select to include City/State and sort by city name. Selecting airport disables option to prevent double-adding and re-enables if removed from active airport list.
- Created new property with full airport name without the prefix.
- Added list of selected airports to right side of browser with control to show/hide the list and a counter of selected airports. Removed previous airport info display and moved select control to above list.
  - Airport div has info and controls to center map on airport or include airport in current map view.
- Added style to Google Map to change colors, changed marker to blue.
- Added infowindow to markers (callout) with airport info and opens/closes with marker click.
